### PR TITLE
Optionally show body and vessel names when mousing over flares

### DIFF
--- a/Source-Code/FlareDraw.cs
+++ b/Source-Code/FlareDraw.cs
@@ -301,6 +301,7 @@ namespace DistantObject
                     double bestBrightness = 0.25; // min luminosity to show vessel name
                     foreach (Vessel v in vesselMeshLookup.Keys)
                     {
+                        if (v == null) continue; // After KSP destroys a vessel it becomes == to null.
                         GameObject mesh = vesselMeshLookup[v];
                         if(!meshRendererLookup.ContainsKey(mesh)) continue;
                         MeshRenderer flareMR = meshRendererLookup[mesh];

--- a/Source-Code/FlareDraw.cs
+++ b/Source-Code/FlareDraw.cs
@@ -301,9 +301,7 @@ namespace DistantObject
                     double bestBrightness = 0.25; // min luminosity to show vessel name
                     foreach (Vessel v in vesselMeshLookup.Keys)
                     {
-                        if (v == null) continue; // After KSP destroys a vessel it becomes == to null.
                         GameObject mesh = vesselMeshLookup[v];
-                        if(!meshRendererLookup.ContainsKey(mesh)) continue;
                         MeshRenderer flareMR = meshRendererLookup[mesh];
                         if (flareMR.material.color.a > 0)
                         {
@@ -311,7 +309,6 @@ namespace DistantObject
                             double mouseVesselAngle = Vector3d.Angle(vectorToVessel, mouseRay.direction);
                             if (mouseVesselAngle < 1.0)
                             {
-                                if (!vesselLuminosityLookup.ContainsKey(v)) continue;
                                 double luminosity = vesselLuminosityLookup[v];
                                 double distance = Vector3d.Distance(FlightCamera.fetch.mainCamera.transform.position, v.transform.position);
                                 double brightness = Math.Log10(luminosity) * (1 - Math.Pow(distance / 750000, 1.25));
@@ -381,10 +378,32 @@ namespace DistantObject
 
             if (flaresEnabled)
                 StartCoroutine("StartUp");
+
+
+            // Remove Vessels from our dictionaries just before they are destroyed.
+            // After they are destroyed they are == null and this confuses Dictionary.
+            GameEvents.onVesselWillDestroy.Add(RemoveVesselFlare);
+
+        }
+
+        private void RemoveVesselFlare(Vessel v)
+        {
+            if (vesselMeshLookup.ContainsKey(v))
+            {
+                if (debugMode) { print("DistObj: Erasing flare for vessel " + v.name); }
+                GameObject flareMesh = vesselMeshLookup[v];
+                meshRendererLookup.Remove(flareMesh);
+                meshVesselLookup.Remove(flareMesh);
+                vesselMeshLookup.Remove(v);
+                vesselLuminosityLookup.Remove(v);
+                DestroyObject(flareMesh);
+            }
         }
 
         private void Update()
         {
+            debugMode = true;
+
             if (flaresEnabled)
             {
                 UpdateVar();
@@ -398,14 +417,10 @@ namespace DistantObject
                 restart:
                 foreach (GameObject flareMesh in meshVesselLookup.Keys)
                 {
-                    if (meshVesselLookup[flareMesh] == null || meshVesselLookup[flareMesh].loaded || !situations.Contains(meshVesselLookup[flareMesh].situation.ToString()))
+                    Vessel v = meshVesselLookup[flareMesh];
+                    if (v == null || v.loaded || !situations.Contains(v.situation.ToString()))
                     {
-                        if (debugMode) { print("DistObj: Erasing flare for vessel " + flareMesh.name); }
-                        meshRendererLookup.Remove(flareMesh);
-                        vesselMeshLookup.Remove(meshVesselLookup[flareMesh]);
-                        vesselLuminosityLookup.Remove(meshVesselLookup[flareMesh]);
-                        meshVesselLookup.Remove(flareMesh);
-                        DestroyObject(flareMesh);
+                        RemoveVesselFlare(v);
                         goto restart;
                     }
 

--- a/Source-Code/SettingsGui.cs
+++ b/Source-Code/SettingsGui.cs
@@ -21,6 +21,7 @@ namespace DistantObject
         private float flareBrightness = 1.0f;
         private bool ignoreDebrisFlare = false;
         private float debrisBrightness = 0.15f;
+        private bool showNames = false;
         private bool renderVessels = false;
         private float maxDistance = 750000f;
         private int renderMode = 1;
@@ -56,7 +57,8 @@ namespace DistantObject
                 flareBrightness = float.Parse(node.GetValue("flareBrightness"));
                 ignoreDebrisFlare = bool.Parse(node.GetValue("ignoreDebrisFlare"));
                 debrisBrightness = float.Parse(node.GetValue("debrisBrightness"));
-                debugMode = bool.Parse(node.GetValue("debugMode"));                
+                debugMode = bool.Parse(node.GetValue("debugMode"));
+                showNames = bool.Parse(node.GetValue("showNames"));
             }
 
             foreach (ConfigNode node in settings.GetNodes("DistantVessel"))
@@ -142,6 +144,12 @@ namespace DistantObject
                     settings.GetNode("DistantFlare").SetValue("debrisBrightness", "" + debrisBrightness);
                     GUILayout.Label(string.Format("{0:0}", 100 * debrisBrightness) + "%");
                     GUILayout.EndHorizontal();
+                }
+
+                if (GUILayout.Button(GetStatus(!showNames) + " showing body names on mouseover"))
+                {
+                    showNames = !showNames;
+                    settings.GetNode("DistantFlare").SetValue("showNames", "" + showNames);
                 }
             }
 


### PR DESCRIPTION
I always find myself wanting to know which planet I'm looking it, so I made body and vessel names show up when you mouse over their flares. This can be turned on/off through a new button in the settings menu. It requires a new "showNames = true/false" line in the settings file.
