### PR TITLE
Check for GalaxyCubeControl being initialized.

### DIFF
--- a/Source-Code/DarkenSky.cs
+++ b/Source-Code/DarkenSky.cs
@@ -16,6 +16,9 @@ namespace DistantObject
 
         public void Awake()
         {
+            if (GalaxyCubeControl.Instance == null)
+                return;
+
             //Load settings
             ConfigNode settings = ConfigNode.Load(KSPUtil.ApplicationRootPath + "GameData/DistantObject/Settings.cfg");
             foreach (ConfigNode node in settings.GetNodes("SkyboxBrightness"))


### PR DESCRIPTION
DarkenSky NREs during KSP startup due to attempting to adjust the galaxy
box too early, so check to make sure it has been initialized before doing
anything.
