### PR TITLE
set the layer to 10 instead of 0 for the flares

### DIFF
--- a/Source-Code/FlareDraw.cs
+++ b/Source-Code/FlareDraw.cs
@@ -55,6 +55,7 @@ namespace DistantObject
             }
 
             MeshRenderer flareMR = flareMesh.GetComponentInChildren<MeshRenderer>();
+            flareMR.gameObject.layer = 10;
             flareMR.material.shader = Shader.Find("KSP/Alpha/Unlit Transparent");
             flareMR.material.color = Color.white;
             flareMR.castShadows = false;
@@ -83,6 +84,7 @@ namespace DistantObject
             flareMesh.SetActive(true);
 
             MeshRenderer flareMR = flareMesh.GetComponentInChildren<MeshRenderer>();
+            flareMR.gameObject.layer = 10;
             flareMR.material.shader = Shader.Find("KSP/Alpha/Unlit Transparent");
             Color color = Color.white;
             if (bodyColorLookup.ContainsKey(referenceBody))


### PR DESCRIPTION
The flares have the layer 0 currently, which is used currently meant for locally visible vessels and parts.
The layer 10 is more appropriate: it's supposed to be used for distant objects such as moons and planets.

This change does not affect how DistantObject works, but allows other mods to properly interact with it when using lights.

The mod I'm currently developing applies a directional light to the player vessel and parts, but Distant Object's flares are affected as well, and shouldn't.
